### PR TITLE
Bugfix: extruder enable pin was not set at all

### DIFF
--- a/dda.c
+++ b/dda.c
@@ -183,6 +183,7 @@ void dda_create(DDA *dda, TARGET *target) {
 		y_enable();
 		if (dda->z_delta)
 			z_enable();
+		e_enable();
 
 		// since it's unusual to combine X, Y and Z changes in a single move on reprap, check if we can use simpler approximations before trying the full 3d approximation.
 		if (dda->z_delta == 0)
@@ -363,6 +364,7 @@ void dda_start(DDA *dda) {
 		y_enable();
 		if (dda->z_delta)
 			z_enable();
+		e_enable();
 
 		// set direction outputs
 		x_direction(dda->x_direction);

--- a/gcode_process.c
+++ b/gcode_process.c
@@ -273,6 +273,7 @@ void process_gcode_command() {
 				x_disable();
 				y_disable();
 				z_disable();
+				e_disable();
 				power_off();
 				for (;;)
 					wd_reset();
@@ -439,6 +440,7 @@ void process_gcode_command() {
 				x_enable();
 				y_enable();
 				z_enable();
+				e_enable();
 				steptimeout = 0;
 				break;
 			// M191- power off
@@ -446,6 +448,7 @@ void process_gcode_command() {
 				x_disable();
 				y_disable();
 				z_disable();
+				e_disable();
 				power_off();
 				break;
 				

--- a/pinio.c
+++ b/pinio.c
@@ -10,6 +10,9 @@ void power_off() {
 	#ifdef	Z_ENABLE_PIN
 		z_disable();
 	#endif
+	#ifdef	E_ENABLE_PIN
+		e_disable();
+	#endif
 
 	#ifdef	STEPPER_ENABLE_PIN
 	WRITE(STEPPER_ENABLE_PIN, STEPPER_ENABLE_INVERT ^ 1);

--- a/pinio.h
+++ b/pinio.h
@@ -45,6 +45,9 @@
 #ifndef	E_INVERT_DIR
 	#define	E_INVERT_DIR 0
 #endif
+#ifndef	E_INVERT_ENABLE
+	#define	E_INVERT_ENABLE 0
+#endif
 
 #ifndef	STEPPER_ENABLE_INVERT
 	#define	STEPPER_ENABLE_INVERT 0
@@ -163,6 +166,14 @@ Stepper Enable Pins
 #else
 	#define	z_enable()					do { } while (0)
 	#define	z_disable()					do { } while (0)
+#endif
+
+#ifdef	E_ENABLE_PIN
+	#define	e_enable()					do { WRITE(E_ENABLE_PIN, E_INVERT_ENABLE); SET_OUTPUT(E_ENABLE_PIN); } while (0)
+	#define	e_disable()					do { WRITE(E_ENABLE_PIN, E_INVERT_ENABLE ^ 1); SET_OUTPUT(E_ENABLE_PIN); } while (0)
+#else
+	#define	e_enable()					do { } while (0)
+	#define	e_disable()					do { } while (0)
 #endif
 
 #endif	/* _PINIO_H */


### PR DESCRIPTION
Silly me, I made a sample configuration file for the Gen6 electronics which has an extruder enable pin, without actually checking that the extruder worked. Sorry about that. This commit fixes that. Macros e_enable() and e_disable() are defined and called where approriate.
