### PR TITLE
A simple bug for overflows in delayMicrosecondsInterruptible function.

### DIFF
--- a/delay.c
+++ b/delay.c
@@ -6,6 +6,10 @@
 
 #include	"watchdog.h"
 
+#if F_CPU != 16000000L
+	#error delayMicrosecondsInterruptible() requires the clock to be 16mhz
+#endif
+
 /// delay microseconds
 /// \param delay time to wait in microseconds
 void delay(uint32_t delay) {
@@ -34,6 +38,8 @@ void delay_ms(uint32_t delay) {
 
 /// internal- wait for up to 65.5ms using a busy loop
 /// \param us time to wait in microseconds
+/// BUG - this code depends on the system clock running  
+/// at 16mhz.
 void delayMicrosecondsInterruptible(uint16_t us)
 {
 	// for a one-microsecond delay, simply return.  the overhead
@@ -41,16 +47,23 @@ void delayMicrosecondsInterruptible(uint16_t us)
 	if (--us == 0)
 		return;
 
-	// the following loop takes a quarter of a microsecond (4 cycles)
-	// per iteration, so execute it four times for each microsecond of
-	// delay requested.
-	us <<= 2;
-
-	// account for the time taken in the preceeding commands.
-	us -= 2;
+	// the following loop takes a microsecond (16 cycles)
+	// per iteration.
 
 	// busy wait
 	__asm__ __volatile__ ("1: sbiw %0,1" "\n\t" // 2 cycles
+	"nop" "\n\t" // 1 cycle
+	"nop" "\n\t" // 1 cycle
+	"nop" "\n\t" // 1 cycle
+	"nop" "\n\t" // 1 cycle
+	"nop" "\n\t" // 1 cycle
+	"nop" "\n\t" // 1 cycle
+	"nop" "\n\t" // 1 cycle
+	"nop" "\n\t" // 1 cycle
+	"nop" "\n\t" // 1 cycle
+	"nop" "\n\t" // 1 cycle
+	"nop" "\n\t" // 1 cycle
+	"nop" "\n\t" // 1 cycle
 	"brne 1b" :
 	"=w" (us) :
 	"0" (us) // 2 cycles


### PR DESCRIPTION
The left shift of by 2 of the variable us overflows for any value > 0x3fff.

Remove shift and increase loop to 16 clocks per cycle.

This fix still has the problem that the delay depends on the system clock being 16 mhz. This should be restructured to use a frequency independent approach. Until then this eliminates the overflow.
