### PR TITLE
Limit effect on dda->c when computing reprap style acceleration.

### DIFF
--- a/dda.c
+++ b/dda.c
@@ -479,12 +479,23 @@ void dda_step(DDA *dda) {
 	#ifdef ACCELERATION_REPRAP
 		// linear acceleration magic, courtesy of http://www.embedded.com/columns/technicalinsights/56800129?printable=true
 		if (dda->accel) {
-			if (
-					((dda->n > 0) && (dda->c > dda->end_c)) ||
-					((dda->n < 0) && (dda->c < dda->end_c))
-				) {
-				dda->c = (int32_t) dda->c - ((int32_t) (dda->c * 2) / dda->n);
-				dda->n += 4;
+			if ((dda->c > dda->end_c) && (dda->n > 0)) {
+				uint32_t new_c = dda->c - (dda->c * 2) / dda->n;
+				if (new_c <= dda->c && new_c > dda->end_c) {
+					dda->c = new_c;
+					dda->n += 4;
+				}
+				else
+					dda->c = dda->end_c;
+			}
+			else if ((dda->c < dda->end_c) && (dda->n < 0)) {
+				uint32_t new_c = dda->c + ((dda->c * 2) / -dda->n);
+				if (new_c >= dda->c && new_c < dda->end_c) {
+					dda->c = new_c;
+					dda->n += 4;
+				}
+				else
+					dda->c = dda->end_c;
 			}
 			else if (dda->c != dda->end_c) {
 				dda->c = dda->end_c;


### PR DESCRIPTION
This fix is really a hack to protect from overflow/underflow
in the reprap acceleration code due to the limited precision 
of the fixed point calculations. It does, however, protect the 
code from accidentally turning off the step timer or setting the
timer interval value outside of the range defined by the current
interval and the ultimate endpoint interval.

This is a cleanup replacement for the code posted on the reprap forum:
http://forums.reprap.org/read.php?147,33082,83467#msg-83467
