### PR TITLE
Add M82/M83 for run-time e_absolute config

### DIFF
--- a/dda.c
+++ b/dda.c
@@ -53,6 +53,19 @@ TARGET current_position __attribute__ ((__section__ (".bss")));
 MOVE_STATE move_state __attribute__ ((__section__ (".bss")));
 
 /*
+ * Config data
+ */
+CONFIG config __attribute__ ((__section__ (".bss"))) = {
+	{
+#ifdef E_ABSOLUTE
+		1,
+#else
+		0,
+#endif
+	}
+} ;
+
+/*
 	utility functions
 */
 
@@ -411,10 +424,10 @@ void dda_create(DDA *dda, TARGET *target) {
 
 	// next dda starts where we finish
 	memcpy(&startpoint, target, sizeof(TARGET));
+
 	// if E is relative, reset it here
-	#ifndef E_ABSOLUTE
+	if ( !config.e_absolute )
 		startpoint.E = startpoint_steps.E = 0;
-	#endif
 }
 
 /*! Start a prepared DDA
@@ -747,16 +760,17 @@ void update_current_position() {
 			current_position.Z = dda->endpoint.Z +
 			                     move_state.z_steps * 1000 / ((STEPS_PER_M_Z + 500) / 1000);
 
-		#ifndef E_ABSOLUTE
+		if ( !config.e_absolute ) {
 			current_position.E = move_state.e_steps * 1000 / ((STEPS_PER_M_E + 500) / 1000);
-		#else
+		}
+		else {
 			if (dda->e_direction)
 				current_position.E = dda->endpoint.E -
 				                     move_state.e_steps * 1000 / ((STEPS_PER_M_E + 500) / 1000);
 			else
 				current_position.E = dda->endpoint.E +
 				                     move_state.e_steps * 1000 / ((STEPS_PER_M_E + 500) / 1000);
-		#endif
+		}
 
 		// current_position.F is updated in dda_start()
 	}

--- a/dda.h
+++ b/dda.h
@@ -199,6 +199,16 @@ typedef struct {
 } DDA;
 
 /*
+ * Dynamic config
+ */
+typedef struct {
+	struct {
+		// Operational params
+		uint8_t					e_absolute	:1; ///< bool: E axis is specified in absolute/relative position
+	};
+} CONFIG ;
+
+/*
 	variables
 */
 
@@ -214,6 +224,9 @@ extern TARGET startpoint_steps;
 
 /// current_position holds the machine's current position. this is only updated when we step, or when G92 (set home) is received.
 extern TARGET current_position;
+
+/// holds dynamic config settings
+extern CONFIG config;
 
 /*
 	methods

--- a/gcode_parse.c
+++ b/gcode_parse.c
@@ -357,14 +357,10 @@ void gcode_parse_char(uint8_t c) {
 
 		if (next_target.option_relative) {
 			next_target.target.X = next_target.target.Y = next_target.target.Z = 0;
-			#ifdef	E_ABSOLUTE
-				next_target.target.E = 0;
-			#endif
 		}
-		#ifndef	E_ABSOLUTE
-			// E always relative
+		if ( !config.e_absolute || next_target.option_relative) {
 			next_target.target.E = 0;
-		#endif
+		}
 	}
 }
 

--- a/gcode_process.c
+++ b/gcode_process.c
@@ -66,9 +66,8 @@ void process_gcode_command() {
 		next_target.target.X += startpoint.X;
 		next_target.target.Y += startpoint.Y;
 		next_target.target.Z += startpoint.Z;
-		#ifdef	E_ABSOLUTE
+		if ( config.e_absolute )
 			next_target.target.E += startpoint.E;
-		#endif
 	}
 	// E ALWAYS relative, otherwise we overflow our registers after only a few layers
 	// 	next_target.target.E += startpoint.E;
@@ -291,9 +290,8 @@ void process_gcode_command() {
 					axisSelected = 1;
 				}
 				if (next_target.seen_E) {
-					#ifdef	E_ABSOLUTE
+					if ( config.e_absolute )
 						startpoint.E = next_target.target.E;
-					#endif
 					axisSelected = 1;
 				}
 
@@ -393,11 +391,14 @@ void process_gcode_command() {
 				tool = next_tool;
 				break;
 
-			// M82 - Set E codes absolute (default)
-			// not implemented
-
-			// M83 - Set E codes relative while in Absolute Coordinates (G90) mode
-			// not implemented
+			// M82- use absolute E coordinates
+			case 82:
+				config.e_absolute = 1;
+				break;
+			// M83- use relative E coordinates
+			case 83:
+				config.e_absolute = 0;
+				break;
 
 			// M84- stop idle hold
 			case 84:


### PR DESCRIPTION
Make E_ABSOLUTE only set a variable in memory.  Convert all
E_ABSOLUTE usage to read config.e_absolute instead.  Add
interpreter for M82/M83 commands to set/clear e_absolute
flag.

Found on http://groups.google.com/group/ultimaker/browse_thread/thread/d76e47d5a9d3c15a

// M82  - Set E codes absolute (default)
// M83  - Set E codes relative while in Absolute Coordinates (G90)
mode

FIXME -- config.e_absolute does not follow G90; should it?
