### PR TITLE
Reduce code complexity and size by iterating axes

### DIFF
--- a/dda.c
+++ b/dda.c
@@ -81,6 +81,15 @@ static const axes_uint32_t PROGMEM c0_P = {
   (uint32_t)((double)F_CPU / SQRT((double)(STEPS_PER_M_E * ACCELERATION / 2000.)))
 };
 
+/// \var search_feedrate_P
+/// \brief desired feedrate for homing on each axis except E
+const axes_uint32_t PROGMEM search_feedrate_P = {
+  SEARCH_FEEDRATE_X,
+  SEARCH_FEEDRATE_Y,
+  SEARCH_FEEDRATE_Z
+
+};
+
 /*! Set the direction of the 'n' axis
 */
 static void set_direction(DDA *dda, enum axis_e n, int dir) {

--- a/dda.h
+++ b/dda.h
@@ -187,6 +187,12 @@ extern TARGET startpoint_steps;
 /// current_position holds the machine's current position. this is only updated when we step, or when G92 (set home) is received.
 extern TARGET current_position;
 
+/// maximum_feedrate values in an indexable array
+extern const axes_uint32_t maximum_feedrate;
+
+/// search_feedrate values in an indexable array
+extern const axes_uint32_t search_feedrate;
+
 /*
 	methods
 */


### PR DESCRIPTION
Following a TODO tip in the code, I worked through the issues to convert all the X, Y, Z and E axis variables into arrays, usually of "axis[X]", "axis[Y]", "axis[Z]" and "axis[E]".  Over several commits I think I have managed to clean these all into working code.  But I have not tested it on a printer.  I have tested it on the PC simulator, but those tests are still fairly limited.

Originally, it was based on the 'cross' branch since I saw some code duplication erupting there. I rebased it onto experimental now, and cross will need a little cleanup to rebase on top of this.  But first it needs a thorough review.

In addition to cleaner code, it also saves us almost 2K flash:

New:

      SIZES             ATmega...  '168    '328(P)    '644(P)    '1280
      FLASH : 15182 bytes          106%       50%        24%       12%
      RAM   :   995 bytes           98%       49%        25%       13%
      EEPROM:    32 bytes            4%        2%         2%        1%

Old:

      SIZES             ATmega...  '168    '328(P)    '644(P)    '1280
      FLASH : 17124 bytes          120%       56%        27%       14%
      RAM   :   995 bytes           98%       49%        25%       13%
      EEPROM:    32 bytes            4%        2%         2%        1%
