### PR TITLE
zungmann's fixes to compile simulator on a Mac

### DIFF
--- a/analog.c
+++ b/analog.c
@@ -24,7 +24,7 @@
 #undef DEFINE_TEMP_SENSOR
 
 static uint8_t adc_counter;
-static volatile uint16_t adc_result[NUM_TEMP_SENSORS] __attribute__ ((__section__ (".bss")));
+static volatile uint16_t _BSS(adc_result[NUM_TEMP_SENSORS]);
 
 #define DEFINE_TEMP_SENSOR(name, type, pin, additional) \
 	((type == TT_THERMISTOR) || (type == TT_AD595)) ? (pin ## _ADC) : 255,

--- a/arduino.h
+++ b/arduino.h
@@ -103,4 +103,8 @@
 #error pins for this chip not defined in arduino.h! If you write an appropriate pin definition and have this firmware work on your chip, please tell us via the forum thread
 #endif
 
+#ifndef _BSS
+  #define _BSS(var) var __attribute__ ((__section__ (".bss")))
+#endif
+
 #endif /* _ARDUINO_H */

--- a/dda.c
+++ b/dda.c
@@ -37,20 +37,20 @@
 
 /// \var startpoint
 /// \brief target position of last move in queue
-TARGET startpoint __attribute__ ((__section__ (".bss")));
+TARGET _BSS(startpoint);
 
 /// \var startpoint_steps
 /// \brief target position of last move in queue, expressed in steps
-TARGET startpoint_steps __attribute__ ((__section__ (".bss")));
+TARGET _BSS(startpoint_steps);
 
 /// \var current_position
 /// \brief actual position of extruder head
 /// \todo make current_position = real_position (from endstops) + offset from G28 and friends
-TARGET current_position __attribute__ ((__section__ (".bss")));
+TARGET _BSS(current_position);
 
 /// \var move_state
 /// \brief numbers for tracking the current state of movement
-MOVE_STATE move_state __attribute__ ((__section__ (".bss")));
+MOVE_STATE _BSS(move_state);
 
 /*! Inititalise DDA movement structures
 */

--- a/dda_queue.c
+++ b/dda_queue.c
@@ -35,7 +35,7 @@ uint8_t	mb_tail = 0;
 /// slot will only be modified in interrupts until the slot is
 /// is no longer live.
 /// The size does not need to be a power of 2 anymore!
-DDA movebuffer[MOVEBUFFER_SIZE] __attribute__ ((__section__ (".bss")));
+DDA _BSS(movebuffer[MOVEBUFFER_SIZE]);
 
 /// check if the queue is completely full
 uint8_t queue_full() {

--- a/extruder/analog.c
+++ b/extruder/analog.c
@@ -18,7 +18,7 @@ static const uint8_t analog_mask = 0
 #undef DEFINE_TEMP_SENSOR
 
 static uint8_t adc_counter;
-static volatile uint16_t adc_result[8] __attribute__ ((__section__ (".bss")));
+static volatile uint16_t _BSS(adc_result[8]);
 
 //! Configure all registers, start interrupt loop
 void analog_init() {

--- a/gcode_parse.c
+++ b/gcode_parse.c
@@ -26,10 +26,10 @@ uint8_t last_field = 0;
 #define crc(a, b)		(a ^ b)
 
 /// crude floating point data storage
-decfloat read_digit					__attribute__ ((__section__ (".bss")));
+decfloat _BSS(read_digit);
 
 /// this is where we store all the data for the current command before we work out what to do with it
-GCODE_COMMAND next_target		__attribute__ ((__section__ (".bss")));
+GCODE_COMMAND _BSS(next_target);
 
 /*
 	decfloat_to_int() is the weakest subject to variable overflow. For evaluation, we assume a build room of +-1000 mm and STEPS_PER_MM_x between 1.000 and 4096. Accordingly for metric units:

--- a/simulator.h
+++ b/simulator.h
@@ -40,6 +40,13 @@
 #define enable_transmit()
 #undef USB_SERIAL
 
+#undef _BSS
+#ifdef __MACH__  // Mac
+  #define _BSS(var) var __attribute__ ((__section__ ("__DATA,.bss")))
+#else
+  #define _BSS(var) var __attribute__ ((__section__ (".bss")))
+#endif
+
 #ifndef _SIMULATOR_H
 #define _SIMULATOR_H
 

--- a/simulator/data_recorder.c
+++ b/simulator/data_recorder.c
@@ -18,7 +18,7 @@ static int32_t values[MAX_PINS];       ///< Pin and value states
 static int pin_count;                  ///< Number of pins we emit
 static void emit_log_data(void);
 
-static void recorder_close(int code, void*x ) {
+static void recorder_close(void) {
   if (!file) return;
   // force last line to emit
   emit_log_data();
@@ -42,7 +42,7 @@ void recorder_init(const char* filename) {
   fprintf(file, "#\n");
 
   fflush(file);
-  on_exit(recorder_close, NULL);
+  atexit((void*)recorder_close);
 }
 
 void add_trace_var(const char* name, int pin) {


### PR DESCRIPTION
Compiling for Mac needs some customizations noticed by zungmann in
the reprap forum, here:

http://forums.reprap.org/read.php?147,33082,279050#msg-279050
- .bss section syntax is different
- on_exit is not supported (but atexit is)
- clock_gettime is not supported
