### PR TITLE
simulator: Respect [XYZE]_INVERT_DIR settings

### DIFF
--- a/simulator/simulator.c
+++ b/simulator/simulator.c
@@ -7,6 +7,7 @@
 // If no time scale specified, use 1/10th real-time for simulator
 #define DEFAULT_TIME_SCALE 10
 
+#include "config.h"
 #include "simulator.h"
 #include "data_recorder.h"
 
@@ -340,18 +341,30 @@ void WRITE(pin_t pin, bool s) {
     switch (pin) {
     case X_STEP_PIN:
       dir = state[X_DIR_PIN] ? 1 : -1;
+      #ifdef X_INVERT_DIR
+        dir = -dir;
+      #endif
       axis = X_AXIS;
       break;
     case Y_STEP_PIN:
       dir = state[Y_DIR_PIN] ? 1 : -1;
+      #ifdef Y_INVERT_DIR
+        dir = -dir;
+      #endif
       axis = Y_AXIS;
       break;
     case Z_STEP_PIN:
       dir = state[Z_DIR_PIN] ? 1 : -1;
+      #ifdef Z_INVERT_DIR
+        dir = -dir;
+      #endif
       axis = Z_AXIS;
       break;
     case E_STEP_PIN:
       dir = state[E_DIR_PIN] ? 1 : -1;
+      #ifdef E_INVERT_DIR
+        dir = -dir;
+      #endif
       axis = E_AXIS;
       break;
     default:


### PR DESCRIPTION
Simulator assumes a basic set of config pins.  Most it ignores
and redefines; but the INVERT_DIR pins it did not, and these
could be useful to simulate.  So teach Simulator to respect them.