### PR TITLE
Makefile-AVR: Update MCU_TARGET=at90usb1286 conditional.

### DIFF
--- a/Makefile-AVR
+++ b/Makefile-AVR
@@ -45,7 +45,7 @@
 MCU_TARGET ?= atmega644p
 # MCU_TARGET ?= atmega1280
 # MCU_TARGET ?= atmega2560
-# MCU_TARGET ?= at90usb1287
+# MCU_TARGET ?= at90usb1286
 # MCU_TARGET ?= atmega32u4
 
 # CPU clock rate


### PR DESCRIPTION
The at90usb1287 is a host-type USB device, and I'm not sure anyone is using it.  I switched the line to
refer to the chip in the teensy board.
