### PR TITLE
debug.h:Align M111 debug bit codes with Repetier-Host.

### DIFF
--- a/debug.h
+++ b/debug.h
@@ -4,16 +4,21 @@
 #include	<stdint.h>
 
 #ifdef	DEBUG
-	#define		DEBUG_PID				1
-	#define		DEBUG_DDA				2
-	#define		DEBUG_POSITION	4
-	#define		DEBUG_ECHO			128
+	#define		DEBUG_ECHO				1
+	#define		DEBUG_INFO				2	
+	#define		DEBUG_ERRORS				4
+	#define		DEBUG_DRYRUN				8
+	#define		DEBUG_PID				16
+	#define		DEBUG_DDA				32
+	#define		DEBUG_POSITION				64
 #else
 	// by setting these to zero, the compiler should optimise the relevant code out
 	#define		DEBUG_PID				0
 	#define		DEBUG_DDA				0
 	#define		DEBUG_POSITION	0
 	#define		DEBUG_ECHO			0
+	#define		DEBUG_INFO				0
+	#define		DEBUG_DRYRUN				0
 #endif
 
 


### PR DESCRIPTION
the pid_tuning branch might be cool, but... I had a couple problems with RepetierHost:

1) the software sends a M111 S15 per https://github.com/repetier/Repetier-Host/blob/f01afccee26c93d2158dbfd04458a65a0b869449/src/RepetierHost/view/PrintPanel.cs#L401

2) The Repetier Host sender filters the G-code through its parser so that:

```
M130 S0.1
```

drops the decimals and sends:

```
N2558M130S0*120
```

You can see the storage for S is repetier is an int from  https://github.com/repetier/Repetier-Host/blob/master/src/RepetierHost/model/GCode.cs#L122  and that the parser casts it to an int at https://github.com/repetier/Repetier-Host/blob/master/src/RepetierHost/model/GCode.cs#L395

Also a lack of spaces seem to screw up the repetier parser so that:

```
M130S1
```

sends:

```
N2670M130*50
```

This patch changes the debug bit codes to align with repetier-host, but can't touch the others.
