### PR TITLE
Fix overflow warning for large steps/meter values

### DIFF
--- a/dda.c
+++ b/dda.c
@@ -74,10 +74,10 @@ static const axes_uint32_t PROGMEM maximum_feedrate_P = {
 /// \brief Initialization constant for the ramping algorithm. Timer cycles for
 ///        first step interval.
 static const axes_uint32_t PROGMEM c0_P = {
-  (uint32_t)((double)F_CPU / SQRT((double)(STEPS_PER_M_X * ACCELERATION / 2000.))),
-  (uint32_t)((double)F_CPU / SQRT((double)(STEPS_PER_M_Y * ACCELERATION / 2000.))),
-  (uint32_t)((double)F_CPU / SQRT((double)(STEPS_PER_M_Z * ACCELERATION / 2000.))),
-  (uint32_t)((double)F_CPU / SQRT((double)(STEPS_PER_M_E * ACCELERATION / 2000.)))
+  (uint32_t)((double)F_CPU / SQRT((double)(STEPS_PER_M_X * (ACCELERATION / 2000.)))),
+  (uint32_t)((double)F_CPU / SQRT((double)(STEPS_PER_M_Y * (ACCELERATION / 2000.)))),
+  (uint32_t)((double)F_CPU / SQRT((double)(STEPS_PER_M_Z * (ACCELERATION / 2000.)))),
+  (uint32_t)((double)F_CPU / SQRT((double)(STEPS_PER_M_E * (ACCELERATION / 2000.))))
 };
 
 /*! Set the direction of the 'n' axis


### PR DESCRIPTION
My printer uses an M5 threaded rod for Z axis with a 0.9deg/step motor. This is driven using 1/16 microstepping, so the steps/meter are 8000000. This large value causes integer overflow warnings in dda.c.
The result of this is that the build window in configtool is so bogged down with the vast amount of warnings that it takes a lot of time for the build to complete. I actually never let it finish because it looked like it never would :)
Anyway, if you want to reproduce the problem before patching, just use the above steps/meter value for Z and see for yourself.

By the way, great work on this software :)