### PR TITLE
Thermistor config

### DIFF
--- a/configtool/thermistortablefile.py
+++ b/configtool/thermistortablefile.py
@@ -103,7 +103,7 @@ def BetaTable(ofp, params, names, settings, finalTable):
   samples = optimizeTempTable(thrm, N, hiadc)
 
   for i in samples:
-    t = int(thrm.temp(i))
+    t = thrm.temp(i)
     if t is None:
       ofp.output("// ERROR CALCULATING THERMISTOR VALUES AT ADC %d" % i)
       continue
@@ -118,7 +118,7 @@ def BetaTable(ofp, params, names, settings, finalTable):
     else:
       c = ","
     ostr = ("    {%4s, %5s}%s // %4d C, %6.0f ohms, %0.3f V,"
-            " %0.2f mW") % (i, t * 4, c, t, int(round(r)),
+            " %0.2f mW") % (i, int(t * 4), c, int(t), int(round(r)),
             vTherm, ptherm * 1000)
     ofp.output(ostr)
 
@@ -146,7 +146,7 @@ def SteinhartHartTable(ofp, params, names, settings, finalTable):
   samples = optimizeTempTable(thrm, N, hiadc)
 
   for i in samples:
-    t = int(thrm.temp(i))
+    t = thrm.temp(i)
     if t is None:
       ofp.output("// ERROR CALCULATING THERMISTOR VALUES AT ADC %d" % i)
       continue
@@ -158,7 +158,7 @@ def SteinhartHartTable(ofp, params, names, settings, finalTable):
     else:
       c = ","
     ofp.output("    {%4d, %5d}%s // %4d C, %6d ohms" %
-               (i, t * 4, c, t, int(round(r))))
+               (i, int(t * 4), c, int(t), int(round(r))))
 
   if finalTable:
     ofp.output("  }")

--- a/simulator.h
+++ b/simulator.h
@@ -142,6 +142,7 @@ void sim_error(const char msg[]);
 void sim_assert(bool cond, const char msg[]);
 void sim_gcode_ch(char ch);
 void sim_gcode(const char msg[]);
+void sim_report_temptables(int sensor) ;
 
 /**
  * Initialize simulator timer and set time scale.

--- a/simulator/analog_sim.c
+++ b/simulator/analog_sim.c
@@ -1,15 +1,41 @@
+#include "temp.h"
 #include "analog.h"
 #include "simulator.h"
+#include <stdio.h>
 
 static bool analog_initialised = false;
 
 void analog_init(void) {
-  sim_info("analog_init: not implemented in simulator");
   analog_initialised = true;
 }
 
+static uint16_t analog_read_value = 0;
 uint16_t analog_read(uint8_t channel) {
   sim_assert(analog_initialised, "analog_init() was not called before analog_read()");
   sim_assert(sim_interrupts, "interrupts disabled");
-  return 0;
+  return analog_read_value;
+}
+
+void sim_report_temptables(int sensor) {
+  int i ;
+  temp_sensor_t s, first = sensor, last = sensor+1 ;
+
+  // sensor is a specific sensor or -1 for "all sensors"
+  if (sensor == -1) {
+    first = 0;
+    last = NUM_TEMP_SENSORS;
+  }
+
+  sei();
+  analog_init();
+  printf("; Temperature sensor test %d\n", sensor);
+  for (s = first; s < last; s++ ) {
+    printf("; Sensor %d\n", s);
+    for (i = 0 ; i < 1024 ; i++ ) {
+      analog_read_value = i ;
+      temp_sensor_tick() ;
+      uint16_t temp = temp_get(s);
+      printf("%d %.2f\n", i, ((float)temp)/4 ) ;
+    }
+  }
 }

--- a/simulator/simulator.c
+++ b/simulator/simulator.c
@@ -45,7 +45,7 @@ int verbose = 1;                ///< 0=quiet, 1=normal, 2=noisy, 3=debug, etc.
 int trace_gcode = 0;            ///< show gcode on the console
 int trace_pos = 0;              ///< show print head position on the console
 
-const char * shortopts = "qgpvt:o::";
+const char * shortopts = "qgpvt:o::T::";
 struct option opts[] = {
   { "quiet", no_argument, &verbose , 0 },
   { "verbose", no_argument, NULL, 'v' },
@@ -53,6 +53,7 @@ struct option opts[] = {
   { "pos", no_argument, NULL, 'p' },
   { "time-scale", required_argument, NULL, 't' },
   { "tracefile", optional_argument, NULL, 'o' },
+  { "report-temptable", optional_argument, NULL, 'T' },
   { 0, 0, 0, 0 }
 };
 
@@ -65,6 +66,7 @@ static void usage(const char *name) {
   printf("   -p || --pos                   show head position on console\n");
   printf("   -t || --time-scale=n          set time-scale; 0=warp-speed, 1=real-time, 2=half-time, etc.\n");
   printf("   -o || --tracefile[=filename]  write simulator pin trace to 'outfile' (default filename=datalog.out)\n");
+  printf("   -T || --report-temptable=n    Report calculated temperatures for all ADC values and exit\n");
   printf("\n");
   exit(1);
 }
@@ -96,6 +98,9 @@ void sim_start(int argc, char** argv) {
     case 'o':
       recorder_init(optarg ? optarg : "datalog.out");
       break;
+    case 'T':
+      sim_report_temptables(optarg ? atoi(optarg) : -1);
+      exit(0);
     default:
       exit(1);
     }

--- a/temp.c
+++ b/temp.c
@@ -196,28 +196,40 @@ static uint16_t temp_table_lookup(uint16_t temp, uint8_t sensor) {
         sersendf_P(PSTR("pin:%d Raw ADC:%d table entry: %d"),
                    temp_sensors[sensor].temp_pin, temp, j);
 
-      // Wikipedia's example linear interpolation formula.
-      // y = ((x - x₀)y₁ + (x₁-x)y₀) / (x₁ - x₀)
-      // y = temp
-      // x = ADC reading
-      // x₀= temptable[j-1][0]
-      // x₁= temptable[j][0]
-      // y₀= temptable[j-1][1]
-      // y₁= temptable[j][1]
-      temp = (
-      // ((x - x₀)y₁
-        ((uint32_t)temp - pgm_read_word(&(temptable[table_num][j-1][0]))) *
-                          pgm_read_word(&(temptable[table_num][j][1]))
-      //             +
-        +
-      //               (x₁-x)y₀)
-        (pgm_read_word(&(temptable[table_num][j][0])) - (uint32_t)temp) *
-          pgm_read_word(&(temptable[table_num][j - 1][1])))
-      //                        /
-        /
-      //                          (x₁ - x₀)
-        (pgm_read_word(&(temptable[table_num][j][0])) -
-         pgm_read_word(&(temptable[table_num][j - 1][0])));
+      #if (TEMPTABLE_FORMAT == 0)
+        // Wikipedia's example linear interpolation formula.
+        // y = ((x - x₀)y₁ + (x₁-x)y₀) / (x₁ - x₀)
+        // y = temp
+        // x = ADC reading
+        // x₀= temptable[j-1][0]
+        // x₁= temptable[j][0]
+        // y₀= temptable[j-1][1]
+        // y₁= temptable[j][1]
+        temp = (
+        // ((x - x₀)y₁
+          ((uint32_t)temp - pgm_read_word(&(temptable[table_num][j-1][0]))) *
+                            pgm_read_word(&(temptable[table_num][j][1]))
+        //             +
+          +
+        //               (x₁-x)y₀)
+          (pgm_read_word(&(temptable[table_num][j][0])) - (uint32_t)temp) *
+            pgm_read_word(&(temptable[table_num][j - 1][1])))
+        //                        /
+          /
+        //                          (x₁ - x₀)
+          (pgm_read_word(&(temptable[table_num][j][0])) -
+           pgm_read_word(&(temptable[table_num][j - 1][0])));
+        #elif (TEMPTABLE_FORMAT == 1)
+          // Linear interpolation using pre-computed slope
+          // y = y₁ - (x-x₁)*d₁
+          #define X1 pgm_read_word(&(temptable[table_num][j][0]))
+          #define Y1 pgm_read_word(&(temptable[table_num][j][1]))
+          #define D1 pgm_read_word(&(temptable[table_num][j][2]))
+
+          temp = Y1 - ((((int32_t)temp - X1) * D1 + (1<<7)) >> 8);
+        #else
+          #error "temptable format unrecognized"
+        #endif
 
       if (DEBUG_PID && (debug_flags & DEBUG_PID))
         sersendf_P(PSTR(" temp:%d.%d"), temp / 4, (temp % 4) * 25);


### PR DESCRIPTION
I noticed the Configtool produces temperature lookup tables which are significantly wrong around 300C where I print nylon and polycarbonate.  I have a list of the correct ADC conversion values for all 1024 possible inputs and you can see the error on this graph.

![output](https://cloud.githubusercontent.com/assets/123908/14445672/30ecc3e2-001d-11e6-8ae6-5834970e0c21.png)

I wrote an algorithm that works like this: 
  * Calculate the ideal values
  * Insert the two extremes into our sample list
  * Calculate the linear approximation of the remaining values
  * Insert the correct value for the "most-wrong" estimation into our sample list
  * Repeat until "n" values are chosen as requested

The updated graph is a much better approximation using the same number of samples:

![fixed](https://cloud.githubusercontent.com/assets/123908/14445695/79d6c4c2-001d-11e6-9883-6a07361669b6.png)

