### PR TITLE
Maybe-fixes #123: Short move step losses

### DIFF
--- a/dda.c
+++ b/dda.c
@@ -763,6 +763,7 @@ void dda_clock() {
   int32_t move_n;
   uint8_t recalc_speed;
   #endif
+  uint8_t current_id ;
 
   dda = queue_current_movement();
   if (dda != last_dda) {
@@ -867,6 +868,7 @@ void dda_clock() {
     // http://www.embedded.com/design/mcus-processors-and-socs/4006438/Generate-stepper-motor-speed-profiles-in-real-time
     // and http://www.atmel.com/images/doc8017.pdf (Atmel app note AVR446)
     ATOMIC_START
+      current_id = dda->id;
       move_step_no = move_state.step_no;
       // All other variables are read-only or unused in dda_step(),
       // so no need for atomic operations.
@@ -918,8 +920,11 @@ void dda_clock() {
 
       // Write results.
       ATOMIC_START
-        dda->c = move_c;
-        dda->n = move_n;
+        // Apply new n & c values only if dda didn't change underneath us
+        if (current_id == dda->id) {
+          dda->c = move_c;
+          dda->n = move_n;
+        }
       ATOMIC_END
     }
   #endif


### PR DESCRIPTION
I had a number of step losses seemingly related to parts of the print involving lots of short moves.  The losses mostly occurred in the Y-axis direction, but sometimes showed up in X as well.  The problems went away when I lowered my acceleration to 300.  I thought my printer might be sticky.  But I came across some problems in dda_clock today by chance that I think might be the root cause.  I set my acceleration back up to 800 (for now) and I'm not seeing any losses so far.

I think this fixes #123 for me, but I need to test more to be sure.  Whether it does or not, I'm fairly certain this does fix a real bug.