### PR TITLE
Acceleration config for each axis separately

### DIFF
--- a/config/printer.mendel.h
+++ b/config/printer.mendel.h
@@ -127,7 +127,10 @@
     Units: mm/s^2
     Useful range: 1 to 10'000
 */
-#define ACCELERATION             1000
+#define ACCELERATION_X           1000
+#define ACCELERATION_Y           1000
+#define ACCELERATION_Z           1000
+#define ACCELERATION_E           1000
 
 /** \def LOOKAHEAD
   Define this to enable look-ahead during *ramping* acceleration to smoothly

--- a/config/printer.mendel90.h
+++ b/config/printer.mendel90.h
@@ -127,7 +127,10 @@
     Units: mm/s^2
     Useful range: 1 to 10'000
 */
-#define ACCELERATION             2000
+#define ACCELERATION_X           2000
+#define ACCELERATION_Y           2000
+#define ACCELERATION_Z           2000
+#define ACCELERATION_E           2000
 
 /** \def LOOKAHEAD
   Define this to enable look-ahead during *ramping* acceleration to smoothly

--- a/config/printer.pcbscriber.h
+++ b/config/printer.pcbscriber.h
@@ -127,7 +127,10 @@
     Units: mm/s^2
     Useful range: 1 to 10'000
 */
-#define ACCELERATION             100
+#define ACCELERATION_X           100
+#define ACCELERATION_Y           100
+#define ACCELERATION_Z           100
+#define ACCELERATION_E           100
 
 /** \def LOOKAHEAD
   Define this to enable look-ahead during *ramping* acceleration to smoothly

--- a/config/printer.tronxy.h
+++ b/config/printer.tronxy.h
@@ -127,7 +127,10 @@
     Units: mm/s^2
     Useful range: 1 to 10'000
 */
-#define ACCELERATION             1000
+#define ACCELERATION_X           1000
+#define ACCELERATION_Y           1000
+#define ACCELERATION_Z           1000
+#define ACCELERATION_E           1000
 
 /** \def LOOKAHEAD
   Define this to enable look-ahead during *ramping* acceleration to smoothly

--- a/config/printer.wolfstrap.h
+++ b/config/printer.wolfstrap.h
@@ -127,7 +127,10 @@
     Units: mm/s^2
     Useful range: 1 to 10'000
 */
-#define ACCELERATION             100
+#define ACCELERATION_X           100
+#define ACCELERATION_Y           100
+#define ACCELERATION_Z           100
+#define ACCELERATION_E           100
 
 /** \def LOOKAHEAD
   Define this to enable look-ahead during *ramping* acceleration to smoothly

--- a/configtool/accelerationpage.py
+++ b/configtool/accelerationpage.py
@@ -12,12 +12,17 @@ class AccelerationPage(wx.Panel, Page):
 
     self.accTypeKeys = ['ACCELERATION_REPRAP', 'ACCELERATION_RAMPING',
                         'ACCELERATION_TEMPORAL']
+    self.accKeys = ['ACCELERATION_X', 'ACCELERATION_Y', 'ACCELERATION_Z',
+                    'ACCELERATION_E']
     self.jerkKeys = ['MAX_JERK_X', 'MAX_JERK_Y', 'MAX_JERK_Z', 'MAX_JERK_E']
 
     self.labels = {'ACCELERATION_REPRAP': "RepRap",
                    'ACCELERATION_RAMPING': "Ramping",
                    'ACCELERATION_TEMPORAL': "Temporal",
-                   'ACCELERATION': "Acceleration:",
+                   'ACCELERATION_X': "X:",
+                   'ACCELERATION_Y': "Y:",
+                   'ACCELERATION_Z': "Z:",
+                   'ACCELERATION_E': "E:",
                    'LOOKAHEAD': "Look Ahead",
                    'MAX_JERK_X': "X:", 'MAX_JERK_Y': "Y:", 'MAX_JERK_Z': "Z:",
                    'MAX_JERK_E': "E:"}
@@ -44,17 +49,17 @@ class AccelerationPage(wx.Panel, Page):
     sbox.AddSpacer((5, 5))
     sz.Add(sbox, pos = (1, 1))
 
-    b = wx.StaticBox(self, wx.ID_ANY, "Ramping Parameters")
+    b = wx.StaticBox(self, wx.ID_ANY, "Ramping Acceleration Parameters")
     b.SetFont(font)
     sbox = wx.StaticBoxSizer(b, wx.VERTICAL)
     sbox.AddSpacer((5, 5))
 
-    k = 'ACCELERATION'
-    tc = self.addTextCtrl(k, 80, self.onTextCtrlFloat)
-    self.textControls[k].Enable(False)
 
-    sbox.Add(tc)
-    sbox.AddSpacer((5, 5))
+    for k in self.accKeys:
+      tc = self.addTextCtrl(k, 80, self.onTextCtrlFloat)
+      self.textControls[k].Enable(False)
+      sbox.Add(tc)
+      sbox.AddSpacer((5, 5))
 
     k = 'LOOKAHEAD'
     cb = self.addCheckBox(k, self.onCheckBox)
@@ -96,20 +101,23 @@ class AccelerationPage(wx.Panel, Page):
       ena = False
 
     self.checkBoxes['LOOKAHEAD'].Enable(ena)
-    self.textControls['ACCELERATION'].Enable(ena)
+    for k in self.accKeys:
+      self.textControls[k].Enable(ena)
     evt.Skip()
 
   def insertValues(self, cfgValues):
     Page.insertValues(self, cfgValues)
 
     self.checkBoxes['LOOKAHEAD'].Enable(False)
-    self.textControls['ACCELERATION'].Enable(False)
+    for k in self.accKeys:
+      self.textControls[k].Enable(False)
     for tag in self.accTypeKeys:
       if tag in cfgValues.keys() and cfgValues[tag]:
         self.radioButtons[tag].SetValue(True)
         if tag == 'ACCELERATION_RAMPING':
           self.checkBoxes['LOOKAHEAD'].Enable(True)
-          self.textControls['ACCELERATION'].Enable(True)
+          for k in self.accKeys:
+            self.textControls[k].Enable(True)
 
   def getValues(self):
     result = Page.getValues(self)

--- a/configtool/printer.generic.h
+++ b/configtool/printer.generic.h
@@ -127,7 +127,10 @@
     Units: mm/s^2
     Useful range: 1 to 10'000
 */
-#define ACCELERATION             100
+#define ACCELERATION_X           100
+#define ACCELERATION_Y           100
+#define ACCELERATION_Z           100
+#define ACCELERATION_E           100
 
 /** \def LOOKAHEAD
   Define this to enable look-ahead during *ramping* acceleration to smoothly

--- a/dda.c
+++ b/dda.c
@@ -63,10 +63,10 @@ static const axes_uint32_t PROGMEM maximum_feedrate_P = {
 /// \brief Initialization constant for the ramping algorithm. Timer cycles for
 ///        first step interval.
 static const axes_uint32_t PROGMEM c0_P = {
-  (uint32_t)((double)F_CPU / sqrt((double)STEPS_PER_M_X * ACCELERATION / 2000.)),
-  (uint32_t)((double)F_CPU / sqrt((double)STEPS_PER_M_Y * ACCELERATION / 2000.)),
-  (uint32_t)((double)F_CPU / sqrt((double)STEPS_PER_M_Z * ACCELERATION / 2000.)),
-  (uint32_t)((double)F_CPU / sqrt((double)STEPS_PER_M_E * ACCELERATION / 2000.))
+  (uint32_t)((double)F_CPU / sqrt((double)STEPS_PER_M_X * ACCELERATION_X / 2000.)),
+  (uint32_t)((double)F_CPU / sqrt((double)STEPS_PER_M_Y * ACCELERATION_Y / 2000.)),
+  (uint32_t)((double)F_CPU / sqrt((double)STEPS_PER_M_Z * ACCELERATION_Z / 2000.)),
+  (uint32_t)((double)F_CPU / sqrt((double)STEPS_PER_M_E * ACCELERATION_E / 2000.))
 };
 #endif
 

--- a/dda_maths.c
+++ b/dda_maths.c
@@ -273,10 +273,10 @@ const uint8_t msbloc (uint32_t v) {
   Pre-calculated constant values for acceleration ramp calculations.
 */
 static const axes_uint32_t PROGMEM acc_ramp_div_P = {
-  (uint32_t)((7200000.0f * ACCELERATION) / STEPS_PER_M_X),
-  (uint32_t)((7200000.0f * ACCELERATION) / STEPS_PER_M_Y),
-  (uint32_t)((7200000.0f * ACCELERATION) / STEPS_PER_M_Z),
-  (uint32_t)((7200000.0f * ACCELERATION) / STEPS_PER_M_E)
+  (uint32_t)((7200000.0f * ACCELERATION_X) / STEPS_PER_M_X),
+  (uint32_t)((7200000.0f * ACCELERATION_Y) / STEPS_PER_M_Y),
+  (uint32_t)((7200000.0f * ACCELERATION_Z) / STEPS_PER_M_Z),
+  (uint32_t)((7200000.0f * ACCELERATION_E) / STEPS_PER_M_E)
 };
 
 /*! Acceleration ramp length in steps.

--- a/home.c
+++ b/home.c
@@ -42,15 +42,15 @@
 //   units: / 1000 for um -> mm; * 60 for mm/s -> mm/min
 #ifdef ENDSTOP_CLEARANCE_X
   #define SEARCH_FAST_X (uint32_t)((double)60. * \
-            sqrt((double)2 * ACCELERATION * ENDSTOP_CLEARANCE_X / 1000.))
+            sqrt((double)2 * ACCELERATION_X * ENDSTOP_CLEARANCE_X / 1000.))
 #endif
 #ifdef ENDSTOP_CLEARANCE_Y
   #define SEARCH_FAST_Y (uint32_t)((double)60. * \
-            sqrt((double)2 * ACCELERATION * ENDSTOP_CLEARANCE_Y / 1000.))
+            sqrt((double)2 * ACCELERATION_Y * ENDSTOP_CLEARANCE_Y / 1000.))
 #endif
 #ifdef ENDSTOP_CLEARANCE_Z
   #define SEARCH_FAST_Z (uint32_t)((double)60. * \
-            sqrt((double)2 * ACCELERATION * ENDSTOP_CLEARANCE_Z / 1000.))
+            sqrt((double)2 * ACCELERATION_Z * ENDSTOP_CLEARANCE_Z / 1000.))
 #endif
 
 static const uint32_t PROGMEM fast_feedrate_P[3] = {

--- a/research/alg2.c
+++ b/research/alg2.c
@@ -12,7 +12,10 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-#define ACCELERATION 10 // mm/s^2
+#define ACCELERATION_X 10 // mm/s^2
+#define ACCELERATION_Y 10 // mm/s^2
+#define ACCELERATION_Z 10 // mm/s^2
+#define ACCELERATION_E 10 // mm/s^2
 
 
 typedef struct {

--- a/testcases/config.h.Profiling
+++ b/testcases/config.h.Profiling
@@ -208,7 +208,10 @@
 	how fast to accelerate when using ACCELERATION_RAMPING.
 		given in mm/s^2, decimal allowed, useful range 1. to 10'000. Start with 10. for milling (high precision) or 1000. for printing
 */
-#define ACCELERATION 50.
+#define ACCELERATION_X 50.
+#define ACCELERATION_Y 50.
+#define ACCELERATION_Z 50.
+#define ACCELERATION_E 50.
 
 /** \def ACCELERATION_TEMPORAL
 	temporal step algorithm


### PR DESCRIPTION
In most printers at least Z and E axis have different mechanics than X and Y. Often X and Y differs as well. Therefore it makes sense to control acceleration of every axis separately. Indeed many other firmwares allow for such config. This change adds ability to configure acceleration for X,Y,Z and E independently