### PR TITLE
Make OctoPrint happily draw temperature curve while waiting for heating

### DIFF
--- a/clock.c
+++ b/clock.c
@@ -96,7 +96,7 @@ static void clock_250ms(void) {
     temp_residency_tick();
 
     if (temp_waiting()) {
-      serial_writestr_P(PSTR("Waiting for target temp\n"));
+      temp_print(TEMP_SENSOR_none);
       wait_for_temp = 1;
     }
     else {


### PR DESCRIPTION
I'm using OctoPrint and found that while waiting for the bed/ext to heat up it got no temperature feedback. So instead of just posting "Waiting...." there's now the current temperature echoed. 