### PR TITLE
pullup resistors

### DIFF
--- a/home.c
+++ b/home.c
@@ -172,34 +172,34 @@ void set_axis_home_position(enum axis_e n, int8_t dir) {
   if (dir < 0) {
     if (n == X) {
       #ifdef X_MIN
-      home_position = (int32_t)(X_MIN * 1000);
+      home_position = (int32_t)(X_MIN * 1000L);
       #endif
     }
     else if (n == Y) {
       #ifdef Y_MIN
-      home_position = (int32_t)(Y_MIN * 1000);
+      home_position = (int32_t)(Y_MIN * 1000L);
       #endif
     }
     else if (n == Z) {
       #ifdef Z_MIN
-      home_position = (int32_t)(Z_MIN * 1000);
+      home_position = (int32_t)(Z_MIN * 1000L);
       #endif
     }
   }
   else {
     if (n == X) {
       #ifdef X_MAX
-      home_position = (int32_t)(X_MAX * 1000);
+      home_position = (int32_t)(X_MAX * 1000L);
       #endif
     }
     else if (n == Y) {
       #ifdef Y_MAX
-      home_position = (int32_t)(Y_MAX * 1000);
+      home_position = (int32_t)(Y_MAX * 1000L);
       #endif
     }
     else if (n == Z) {
       #ifdef Z_MAX
-      home_position = (int32_t)(Z_MAX * 1000);
+      home_position = (int32_t)(Z_MAX * 1000L);
       #endif
     }
   }


### PR DESCRIPTION
I use teacup with arduino uno and cnc shield v3.My endstops are simple microswithes.
The pullup resistor option is set in printer config file, but when looking with a multimeter
on endstops pins, the logic high level never goes high but is as max a little bit less
than 0.3 volts when endstops are open, showing the pins in a floating state.
I found the explanation in the dda.c file line 502 which call endstops_on in the pinio.h file, lines 456 and 457.
The pullups resistors are only set during endstop check from line 502 to line 857 in dda.c.
Where are the benefits to do so?.
From an electronician point of view it's a bad idea to let floating an input at the end of a long wire when switch is open (electric noise and static discharge risk) .
When using commercial microswith or opto endstop module, their internal pullup mask this floating state.
Why not set pullup like in standard Arduino language in setup procedure, moving it to pinio.c file in pinio_init line 13.
I tried ,seems to work without problems.

I have another query : i completed board.cnc-shield-v3.h to be able to define 2 sensors + 2 heaters + 1 fan and psu drive with UNO board.
I named it board.cnc-shield-v3-full.h,as it use all available pins on UNO,they can be accessed on cnc-shiel-v3 connectors.
Is there an interest to add it in teacup ? (it's not a personal config,there is no change other than use only more UNO pins).

My last query : i saw some teacup videos installations on youtube displaying program size and ram usage similar to arduino ide after loading.
teacup master don't.
I tried avr dude option -v verbose in settings,got more infos but not the ones i wanted,
Could be usefull to set some options on teacup firmware. Do you know the option to display it ?

Thank you very much for that nice software.
Kind regards.